### PR TITLE
Chages to get docker-compose functional.

### DIFF
--- a/src/backend/DeltaTre.Search.Domain/Extensions/GuardClauseExtensions.cs
+++ b/src/backend/DeltaTre.Search.Domain/Extensions/GuardClauseExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using System.Globalization;
 using Ardalis.GuardClauses;
 using DeltaTre.Search.Domain.Seedwork;
 
@@ -27,7 +29,15 @@ namespace DeltaTre.Search.Domain.Extensions
         private static void ThrowError<T>(string message)
             where T : DomainException
         {
-            throw (T)Activator.CreateInstance(typeof(T), new object[] { message });
+            throw
+            //this was throwing the following expction because of the optional parameters you have in WordsException:
+            // System.MissingMethodException: Constructor on type 'DeltaTre.Search.Domain.Words.WordsException' not found.
+            //(T)Activator.CreateInstance(typeof(T), new object[] { message });
+            (T)Activator.CreateInstance(typeof(T),
+                BindingFlags.CreateInstance |
+                BindingFlags.Public |
+                BindingFlags.Instance |
+                BindingFlags.OptionalParamBinding, null, new object[] { message, Type.Missing, Type.Missing , Type.Missing }, CultureInfo.CurrentCulture);
         }
     }
 }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.4'
 services:
   deltaTre.search.presentation.rpc:
     image: ${DOCKER_REGISTRY-}deltatre.grpc
+    hostname: deltaTre.search.presentation.rpc
     build:
       context: ./backend
       dockerfile: DeltaTre.Search.Presentation.Rpc/Dockerfile
@@ -13,6 +14,7 @@ services:
 
   deltaTre.presentation.api:
     image: ${DOCKER_REGISTRY-}deltatre.api
+    hostname: deltaTre.presentation.api
     build:
       context: ./frontend
       dockerfile: DeltaTre.Presentation.Api/Dockerfile

--- a/src/frontend/DeltaTre.Presentation.Api/ConfigureServicesExtensions.cs
+++ b/src/frontend/DeltaTre.Presentation.Api/ConfigureServicesExtensions.cs
@@ -24,6 +24,9 @@ namespace DeltaTre.Presentation.Api
                 c.Address = new Uri(config.Server);
             });
 
+            // see: https://github.com/grpc/grpc-dotnet/issues/626
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
             services.ConfigureHealthCheck();
             services.AddMediatR(typeof(SearchWordQuery).Assembly);
             services.AddTransient<IWordService, GrpcWordService>();

--- a/src/frontend/DeltaTre.Presentation.Api/appsettings.json
+++ b/src/frontend/DeltaTre.Presentation.Api/appsettings.json
@@ -1,13 +1,14 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "Microsoft": "Debug",
+      "Microsoft.Hosting.Lifetime": "Debug",
+      "Grpc": "Debug"
     }
   },
   "AllowedHosts": "*",
   "GrpcConfig": {
-    "Server":  "https://localhost:5001" 
+    "Server":  "http://localhost:5001" 
   }
 }


### PR DESCRIPTION
* There's a workaround to get the microsoft gRPC client working with http:
AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
* Once that was working getting your docker-compose.yaml to work was easy.
* Fix a problem with instantiation in error handling.